### PR TITLE
Feat/5 search bar

### DIFF
--- a/AppleMusicClone.xcodeproj/project.pbxproj
+++ b/AppleMusicClone.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		790FC5BB2874184000B26D20 /* HintResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790FC5B72874184000B26D20 /* HintResponse.swift */; };
 		790FC5BD2874184E00B26D20 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790FC5BC2874184E00B26D20 /* SearchView.swift */; };
 		790FC5C02874745F00B26D20 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790FC5BF2874745F00B26D20 /* SearchViewModel.swift */; };
-		790FC5C82875AD0700B26D20 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790FC5C72875AD0700B26D20 /* MainView.swift */; };
 		7933983428732C58007584EC /* Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7933983328732C58007584EC /* Manager.swift */; };
 		7933983628732CEA007584EC /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7933983528732CEA007584EC /* View+Extension.swift */; };
 		7933983828732D92007584EC /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7933983728732D92007584EC /* Constants.swift */; };
@@ -27,6 +26,8 @@
 		7949F5E92876F98B00AAEFD4 /* PlaylistRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7949F5E82876F98B00AAEFD4 /* PlaylistRow.swift */; };
 		7949F5EB2876FAD000AAEFD4 /* HintRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7949F5EA2876FAD000AAEFD4 /* HintRow.swift */; };
 		7949F5ED2877214300AAEFD4 /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7949F5EC2877214300AAEFD4 /* Secret.swift */; };
+		A968EFF828799B6C004BEFE6 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A968EFF728799B6C004BEFE6 /* MainView.swift */; };
+		A968EFFA28799CD7004BEFE6 /* SearchBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A968EFF928799CD7004BEFE6 /* SearchBarViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,7 +43,6 @@
 		790FC5B72874184000B26D20 /* HintResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HintResponse.swift; sourceTree = "<group>"; };
 		790FC5BC2874184E00B26D20 /* SearchView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		790FC5BF2874745F00B26D20 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
-		790FC5C72875AD0700B26D20 /* MainView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MainView.swift; path = "../../../AppleMusicClone 3/AppleMusicClone/Views/MainView.swift"; sourceTree = "<group>"; };
 		7933983328732C58007584EC /* Manager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Manager.swift; sourceTree = "<group>"; };
 		7933983528732CEA007584EC /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		7933983728732D92007584EC /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -51,6 +51,8 @@
 		7949F5E82876F98B00AAEFD4 /* PlaylistRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistRow.swift; sourceTree = "<group>"; };
 		7949F5EA2876FAD000AAEFD4 /* HintRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HintRow.swift; sourceTree = "<group>"; };
 		7949F5EC2877214300AAEFD4 /* Secret.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secret.swift; sourceTree = "<group>"; };
+		A968EFF728799B6C004BEFE6 /* MainView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		A968EFF928799CD7004BEFE6 /* SearchBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +112,7 @@
 			isa = PBXGroup;
 			children = (
 				790FC5BC2874184E00B26D20 /* SearchView.swift */,
+				A968EFF928799CD7004BEFE6 /* SearchBarViewController.swift */,
 				7949F5E42876F96800AAEFD4 /* SongRow.swift */,
 				7949F5E62876F97100AAEFD4 /* ArtistRow.swift */,
 				7949F5E82876F98B00AAEFD4 /* PlaylistRow.swift */,
@@ -121,7 +124,7 @@
 		7933982C287326AB007584EC /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				790FC5C72875AD0700B26D20 /* MainView.swift */,
+				A968EFF728799B6C004BEFE6 /* MainView.swift */,
 				790FC5BE2874185000B26D20 /* SearchViews */,
 			);
 			path = Views;
@@ -250,9 +253,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				790FC5BB2874184000B26D20 /* HintResponse.swift in Sources */,
+				A968EFF828799B6C004BEFE6 /* MainView.swift in Sources */,
 				7949F5E52876F96800AAEFD4 /* SongRow.swift in Sources */,
-				790FC5C82875AD0700B26D20 /* MainView.swift in Sources */,
 				7933983828732D92007584EC /* Constants.swift in Sources */,
+				A968EFFA28799CD7004BEFE6 /* SearchBarViewController.swift in Sources */,
 				790C4919287016D4001304C6 /* ContentView.swift in Sources */,
 				790FC5B32874183600B26D20 /* Webservice.swift in Sources */,
 				7949F5E92876F98B00AAEFD4 /* PlaylistRow.swift in Sources */,

--- a/AppleMusicClone/AppleMusicCloneApp.swift
+++ b/AppleMusicClone/AppleMusicCloneApp.swift
@@ -11,7 +11,8 @@ import SwiftUI
 struct AppleMusicCloneApp: App {
     var body: some Scene {
         WindowGroup {
-            MainView()
+            SearchView()
+//            MainView()
         }
     }
 }

--- a/AppleMusicClone/Views/MainView.swift
+++ b/AppleMusicClone/Views/MainView.swift
@@ -30,7 +30,7 @@ struct MainView: View {
                     Text("보관함")
                 }
 
-            Text("4")
+            SearchView()
                 .tabItem {
                     Image(systemName: "magnifyingglass")
                     Text("검색")

--- a/AppleMusicClone/Views/SearchViews/ArtistRow.swift
+++ b/AppleMusicClone/Views/SearchViews/ArtistRow.swift
@@ -27,6 +27,7 @@ struct ArtistRow: View {
                     Text(searchViewModel.artists[index].inform)
                     Spacer()
                 }
+                Divider()
             }
         }
         

--- a/AppleMusicClone/Views/SearchViews/PlaylistRow.swift
+++ b/AppleMusicClone/Views/SearchViews/PlaylistRow.swift
@@ -27,6 +27,7 @@ struct PlaylistRow: View {
                     Text(searchViewModel.playlists[index].inform)
                     Spacer()
                 }
+                Divider()
             }
         }
         

--- a/AppleMusicClone/Views/SearchViews/SearchBarViewController.swift
+++ b/AppleMusicClone/Views/SearchViews/SearchBarViewController.swift
@@ -1,15 +1,17 @@
+
+//  Created by Rookie on 2022/07/05.
+//
+
 import SwiftUI
 
-struct SearchBar<Content: View>: UIViewControllerRepresentable {
+struct SearchBar: UIViewControllerRepresentable {
     
     var placeholder: String = "아티스트, 노래, 가사 등"
-    var searchScopeTitle: [String] = ["Apple music", "보관함"]
+    var searchScopeTitles: [String] = ["Apple music", "보관함"]
     
     @Binding var isSearching: Bool
     @Binding var selectedScope: Int
     @Binding var text: String
-    
-    @ViewBuilder var content: () -> Content
     
     //MARK: 부모뷰의 data 변화를 감지하기위해 사용해야하는 클래스
     class Coordinator: NSObject, UISearchResultsUpdating, UISearchBarDelegate, UISearchControllerDelegate {
@@ -39,7 +41,7 @@ struct SearchBar<Content: View>: UIViewControllerRepresentable {
         
         let searchController =  UISearchController(searchResultsController: nil)
         searchController.searchResultsUpdater = context.coordinator
-        searchController.searchBar.scopeButtonTitles = self.searchScopeTitle
+        searchController.searchBar.scopeButtonTitles = self.searchScopeTitles
         searchController.searchBar.placeholder = placeholder
         
         return SearchBarViewController(searchController: searchController, isSearching: $isSearching)

--- a/AppleMusicClone/Views/SearchViews/SearchBarViewController.swift
+++ b/AppleMusicClone/Views/SearchViews/SearchBarViewController.swift
@@ -1,0 +1,73 @@
+
+import SwiftUI
+
+class SearchBarViewController: UIViewController {
+    var searchController = UISearchController()
+    
+    init(searchController: UISearchController) {
+        self.searchController = searchController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMove(toParent parent: UIViewController?) {
+        super.didMove(toParent: parent)
+        guard let parent = parent, parent.navigationItem.searchController == nil else  {return}
+        parent.navigationItem.searchController = searchController
+    }
+}
+
+struct SearchBar<Content: View>: UIViewControllerRepresentable {
+
+    typealias UIViewControllerType = SearchBarViewController
+    
+    var placeholder: String = "아티스트, 노래, 가사 등"
+    @Binding var text: String
+    
+    @ViewBuilder var content: () -> Content
+
+    class Coordinator: NSObject, UISearchResultsUpdating, UISearchBarDelegate, UISearchControllerDelegate {
+
+        @Binding var text: String
+        init(text: Binding<String>) {
+            _text = text
+        }
+
+        func updateSearchResults(for searchController: UISearchController) {
+
+            if( self.text != searchController.searchBar.text ) {
+                self.text = searchController.searchBar.text ?? ""
+            }
+        }
+
+        func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        }
+
+        func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
+        }
+
+        func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        }
+    }
+
+    func makeCoordinator() -> SearchBar.Coordinator {
+        return Coordinator(text: $text)
+    }
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<SearchBar>) -> UIViewControllerType {
+
+        let searchController =  UISearchController(searchResultsController: nil)
+        searchController.searchResultsUpdater = context.coordinator
+        searchController.searchBar.scopeButtonTitles = ["Apple music", "보관함"]
+        searchController.searchBar.placeholder = placeholder
+        searchController.obscuresBackgroundDuringPresentation = false
+        return SearchBarViewController(searchController: searchController)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: UIViewControllerRepresentableContext<SearchBar>) {
+    }
+}
+

--- a/AppleMusicClone/Views/SearchViews/SearchView.swift
+++ b/AppleMusicClone/Views/SearchViews/SearchView.swift
@@ -10,31 +10,36 @@ import Combine
 
 struct SearchView: View {
     
-    @State private var location = ""
-    @State private var category: searchCategory = .appleMusic
-    @StateObject var searchViewModel: SearchViewModel = SearchViewModel()
-    
-    
+    @State private var isSearching: Bool = false
+    @State private var selectedScopeIndex : Int = 0
+    @State private var searchText: String = ""
+    @StateObject private var searchViewModel: SearchViewModel = SearchViewModel()
+
     var body: some View {
         
         NavigationView {
-            VStack(spacing: 10) {
-                ///TODO: 커스텀 텍스트 필드
-                SearchBar(text: $location, content: {})
+            VStack(spacing: -25) {
+                SearchBar(isSearching: $isSearching, selectedScope: $selectedScopeIndex, text: $searchText, content: {})
                     .frame(height: 0)
                     .padding()
-                    .onChange(of: location) { _ in
-                        searchViewModel.fetch(location)
+                    .onChange(of: searchText) { _ in
+                        searchViewModel.fetch(searchText)
                     }
-                if location.count > 0 {
-                    ScrollView(.vertical) {
+                ScrollView(.vertical) {
+                    if isSearching == true && searchText.count == 0 {
+                        Text("최근 검색한 항목")
+                            .padding(.leading, 20)
+                            .frame(width: UIScreen.main.bounds.width, alignment: .leading)
+                    }
+                    
+                    if searchText.count > 0 && selectedScopeIndex == 0 {
                         HintRow(searchViewModel: searchViewModel)
                         SongRow(searchViewModel: searchViewModel)
                         PlaylistRow(searchViewModel: searchViewModel)
                         ArtistRow(searchViewModel: searchViewModel)
                     }
-                    Spacer()
                 }
+                Spacer()
             }
             .padding(.horizontal, 20)
             .navigationTitle("검색")
@@ -45,20 +50,6 @@ struct SearchView: View {
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
         SearchView()
-    }
-}
-
-extension SearchView {
-    
-    private func searchPicker() -> some View {
-        
-        Picker("category", selection: $category) {
-            ForEach(searchCategory.allCases, id: \.self) { category in
-                let categoryString = category.rawValue
-                Text(categoryString).tag(categoryString)
-            }
-        }
-        .pickerStyle(.segmented)
     }
 }
 

--- a/AppleMusicClone/Views/SearchViews/SearchView.swift
+++ b/AppleMusicClone/Views/SearchViews/SearchView.swift
@@ -14,29 +14,40 @@ struct SearchView: View {
     @State private var selectedScopeIndex : Int = 0
     @State private var searchText: String = ""
     @StateObject private var searchViewModel: SearchViewModel = SearchViewModel()
-
+    
     var body: some View {
         
         NavigationView {
             VStack(spacing: -25) {
-                SearchBar(isSearching: $isSearching, selectedScope: $selectedScopeIndex, text: $searchText, content: {})
+                SearchBar(isSearching: $isSearching, selectedScope: $selectedScopeIndex, text: $searchText)
                     .frame(height: 0)
                     .padding()
                     .onChange(of: searchText) { _ in
                         searchViewModel.fetch(searchText)
                     }
+                
                 ScrollView(.vertical) {
-                    if isSearching == true && searchText.count == 0 {
-                        Text("최근 검색한 항목")
-                            .padding(.leading, 20)
-                            .frame(width: UIScreen.main.bounds.width, alignment: .leading)
-                    }
-                    
-                    if searchText.count > 0 && selectedScopeIndex == 0 {
-                        HintRow(searchViewModel: searchViewModel)
-                        SongRow(searchViewModel: searchViewModel)
-                        PlaylistRow(searchViewModel: searchViewModel)
-                        ArtistRow(searchViewModel: searchViewModel)
+                    if isSearching == true {
+                        if selectedScopeIndex == 0 {
+                            if searchText.count == 0 {
+                                Text("최근 검색한 항목")
+                                    .padding(.leading, 20)
+                                    .frame(width: UIScreen.main.bounds.width, alignment: .leading)
+                            } else if searchText.count > 0 {
+                                HintRow(searchViewModel: searchViewModel)
+                                SongRow(searchViewModel: searchViewModel)
+                                PlaylistRow(searchViewModel: searchViewModel)
+                                ArtistRow(searchViewModel: searchViewModel)
+                            }
+                        } else if selectedScopeIndex == 1 {
+                            if searchText.count == 0 {
+                                Text("최근 검색한 항목")
+                                    .padding(.leading, 20)
+                                    .frame(width: UIScreen.main.bounds.width, alignment: .leading)
+                            } else if searchText.count > 0 {
+                                Text("유저의 보관함 리스트")
+                            }
+                        }
                     }
                 }
                 Spacer()

--- a/AppleMusicClone/Views/SearchViews/SearchView.swift
+++ b/AppleMusicClone/Views/SearchViews/SearchView.swift
@@ -14,27 +14,31 @@ struct SearchView: View {
     @State private var category: searchCategory = .appleMusic
     @StateObject var searchViewModel: SearchViewModel = SearchViewModel()
     
+    
     var body: some View {
         
-        VStack(spacing: 10) {
-            ///TODO: 커스텀 텍스트 필드
-            TextField("Your Location", text: $location)
-                .padding()
-                .onChange(of: location) { _ in
-                    searchViewModel.fetch(location)
+        NavigationView {
+            VStack(spacing: 10) {
+                ///TODO: 커스텀 텍스트 필드
+                SearchBar(text: $location, content: {})
+                    .frame(height: 0)
+                    .padding()
+                    .onChange(of: location) { _ in
+                        searchViewModel.fetch(location)
+                    }
+                if location.count > 0 {
+                    ScrollView(.vertical) {
+                        HintRow(searchViewModel: searchViewModel)
+                        SongRow(searchViewModel: searchViewModel)
+                        PlaylistRow(searchViewModel: searchViewModel)
+                        ArtistRow(searchViewModel: searchViewModel)
+                    }
+                    Spacer()
                 }
-            
-            searchPicker()
-            
-            ScrollView(.vertical) {
-                HintRow(searchViewModel: searchViewModel)
-                SongRow(searchViewModel: searchViewModel)
-                PlaylistRow(searchViewModel: searchViewModel)
-                ArtistRow(searchViewModel: searchViewModel)
             }
-            Spacer()
+            .padding(.horizontal, 20)
+            .navigationTitle("검색")
         }
-        .padding(.horizontal, 20)
     }
 }
 

--- a/AppleMusicClone/Views/SearchViews/SongRow.swift
+++ b/AppleMusicClone/Views/SearchViews/SongRow.swift
@@ -36,8 +36,8 @@ struct SongRow: View {
                             .foregroundColor(.primary)
                         Spacer()
                     }
-                    
                 }
+                Divider()
             }
         }
     }


### PR DESCRIPTION
## 작업 내용

1. 애플 뮤직의 검색창과 동일한 UI가 완성되었습니다. (검색창 탭시, 전환 애니메이션 포함)
2. 변수명 수정 및 Divider 삽입 등, 기존 코드 중 UI와 관련된 코드가 일부 수정되었습니다.
3. 검색어 입력 여부와 Scope Bar 선택에 따라 검색창 아래 보여지는 컨텐츠가 달라지도록 수정했습니다.

## 고민한 내용

1. 기존 코드리뷰에서 나왔던 사항들을 반영해서 변수명과 인덴테이션을 신경써서 작업했습니다.
2. Uikit 서치바를 SwiftUI에 직관적으로 embed 될 수 있게 노력했습니다.

## 리뷰 받고 싶은 내용 ( 질문할 내용 )
SearchView에 if문을 남발한 거 같은데 뭔가 예쁘게 고칠 수 있을 거 같기도합니다.
UIkit가 좀 미숙한데, 불필요하게 쓴 코드는 없는지 직관적으로 잘 정리되어있는지 궁금하네요

## Screenshot

https://user-images.githubusercontent.com/103009135/178142767-2630bf79-66af-4a9f-9fae-e3187a696d42.mov


